### PR TITLE
Atamon/api changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,5 +17,7 @@ module.exports = {
   // looks like "named mixins" in backbone.cocktail, but are not supported as such in .mixin, yet
   mixins: {
     subset: require('./subset/CollectionSubsetMixin')
-  }
+  },
+
+  enableMixins: mixins.enable.bind(mixins)
 };

--- a/mixins/BackboneCocktail.js
+++ b/mixins/BackboneCocktail.js
@@ -24,4 +24,4 @@ module.exports = {
       Backbone.View.mixin =
       Backbone.History.mixin = mixin;
   }
-}
+};

--- a/mixins/BackboneCocktail.js
+++ b/mixins/BackboneCocktail.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var cocktail = require('backbone.cocktail');
+var underscore = require('underscore');
 
 var mixin = function(obj, fn) {
   var parent = this;
@@ -17,11 +18,17 @@ var mixin = function(obj, fn) {
 };
 
 module.exports = {
-  enable: function(Backbone) {
-    Backbone.Model.mixin =
-      Backbone.Collection.mixin =
-      Backbone.Router.mixin =
-      Backbone.View.mixin =
-      Backbone.History.mixin = mixin;
+  enable: function(target) {
+    if (underscore.isArray(target)) {
+      target.forEach(function (component) {
+        component.mixin = mixin;
+      });
+    } else {
+      target.Model.mixin =
+        target.Collection.mixin =
+        target.Router.mixin =
+        target.View.mixin =
+        target.History.mixin = mixin;
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/Yolean/yobo",
   "dependencies": {
     "backbone": "^1.1.2",
+    "backbone-collection-proxy": "^0.2.5",
     "backbone-filtered-collection": "^0.4.0",
     "backbone.cocktail": "^0.5.10",
     "underscore": "^1.8.2"

--- a/test/ExportSpec.js
+++ b/test/ExportSpec.js
@@ -27,4 +27,8 @@ describe('yobo module', function() {
     expect(yobo._).to.exist();
   });
 
+  it('Exports .enableMixins, to enable mixins for external Backbone components', function () {
+    expect(yobo.enableMixins).to.exist();
+    expect(yobo.enableMixins).to.be.a('function');
+  });
 });

--- a/test/MixinSpec.js
+++ b/test/MixinSpec.js
@@ -11,6 +11,27 @@ describe("#mixin", function() {
     expect(yobo.Collection.mixin).to.be.a('function');
   });
 
+  it("can be enabled on external components through yobo.enableMixins", function () {
+    var subject1 = {}, subject2 = {};
+    yobo.enableMixins([subject1, subject2]);
+    expect(subject1.mixin).to.exist();
+    expect(subject2.mixin).to.exist();
+
+    var subject3 = {
+      Collection: {},
+      Model: {},
+      View: {},
+      Router: {},
+      History: {},
+    };
+    yobo.enableMixins(subject3);
+    expect(subject3.Collection.mixin).to.exist();
+    expect(subject3.Model.mixin).to.exist();
+    expect(subject3.View.mixin).to.exist();
+    expect(subject3.Router.mixin).to.exist();
+    expect(subject3.History.mixin).to.exist();
+  });
+
   xit("Is a function on View, Router, History", function() {
 
   });


### PR DESCRIPTION
This enables a user of yobo to do

```
var yobo = require('yobo');
yobo.enableMixins([Task.Model, Task.Collection]);
Task.Collection.mixin(yobo.mixins.subset);
```

Which can be very helpful if you already have a Backbone extension that you wish to set up mixins for. Note that the exposed function can enable a full set of Backbone components, as well as an array of individual ones..
