### PR TITLE
Relaxed _isModel, anything with .attributes is a model

### DIFF
--- a/collection/LaxModel.js
+++ b/collection/LaxModel.js
@@ -3,6 +3,9 @@ module.exports = function(Collection) {
 
   Collection.prototype._isModel = function(model) {
     if (typeof model.attributes === 'object' && typeof model.cid === 'string') {
+      if (typeof model.on !== 'function' || typeof model.trigger !== 'function') {
+        throw new Error('Backbone requires Model to have .on and .trigger functions. Use Model, Backbone.Events or https://www.npmjs.com/package/bev.');
+      }
       return true;
     }
     if (typeof model.attributes === 'object' && typeof model.cid === 'undefined') {

--- a/collection/LaxModel.js
+++ b/collection/LaxModel.js
@@ -1,0 +1,8 @@
+
+module.exports = function(Collection) {
+
+  Collection.prototype._isModel = function(model) {
+    return typeof model.attributes === 'object';
+  };
+
+};

--- a/collection/LaxModel.js
+++ b/collection/LaxModel.js
@@ -2,7 +2,16 @@
 module.exports = function(Collection) {
 
   Collection.prototype._isModel = function(model) {
-    return typeof model.attributes === 'object';
+    if (typeof model.attributes === 'object' && typeof model.cid === 'string') {
+      return true;
+    }
+    if (typeof model.attributes === 'object' && typeof model.cid === 'undefined') {
+      throw new Error('Invalid Model instance, has .attributes but not .cid');
+    }
+    if (typeof model.attributes === 'undefined' && typeof model.cid !== 'undefined') {
+      throw new Error('Invalid Model instance, has .cid but not .attributes');
+    }
+    return false;
   };
 
 };

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ var underscore = require('underscore');
 var mixins = require('./mixins/BackboneCocktail');
 mixins.enable(backbone);
 
+var laxModel = require('./collection/LaxModel.js');
+laxModel(backbone.Collection);
+
 module.exports = {
 
   _: underscore,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yobo",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "Yolean Backbone",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/Yolean/yobo",
   "dependencies": {
-    "backbone": "~1.1.2",
+    "backbone": "~1.2.0",
     "backbone-filtered-collection": "^0.4.0",
     "backbone.cocktail": "^0.5.10",
     "underscore": "^1.8.2"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "backbone": "~1.2.0",
     "backbone-filtered-collection": "^0.4.0",
     "backbone.cocktail": "^0.5.10",
-    "underscore": "^1.8.2"
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "chai": "^1.10.0",

--- a/test/CollectionSpec.js
+++ b/test/CollectionSpec.js
@@ -1,0 +1,55 @@
+
+var expect = require('chai').expect;
+
+var yobo = require('../');
+
+describe("Collection", function() {
+
+  // Or would there be a point with keeping the unmodified Collection class?
+  it("yobo.Collection is same as yobo.Backbone.Collection", function() {
+    expect(yobo.Collection).to.equal(yobo.Backbone.Collection);
+  });
+
+  describe("add", function() {
+
+    it("Accepts anything that looks like a Backbone model", function() {
+      var c = new yobo.Collection();
+      var m1real = new yobo.Model({prop: 'val'});
+      var m1 = yobo._.clone(m1real);
+      expect(m1 instanceof yobo.Model).to.be.false;
+      expect(m1.attributes.prop).to.equal('val');
+
+      var added = c.add(m1);
+      expect(added.attributes.prop).to.equal('val');
+      expect(added).to.equal(m1);
+      expect(c.at(0)).to.equal(m1);
+    });
+
+    it("Wraps any object that does not have .attributes", function() {
+      var c = new yobo.Collection();
+      var added = c.add({prop: 'val'});
+      expect(added.get('prop')).to.equal('val');
+      expect(added.prop).to.not.exist;
+    });
+
+    it("Thus requires a real model instance if there is an attribute called 'attributes'", function() {
+      var c = new yobo.Collection();
+      // Should work but will probably warn a lot
+      //var added = c.add({attributes: 'val'});
+      var m1 = new yobo.Model({attributes: 'val'});
+      var added = c.add(m1);
+      expect(added).to.equal(m1);
+      expect(added.attributes.attributes).to.exist;
+    });
+
+    it("Consistently denies automatic wrapping if the model type has been unset", function() {
+      var MyCollection = yobo.Collection.extend({model: undefined});
+      expect(function() {
+        new MyCollection().add({prop: 'val'});
+      }).to.throw();
+    });
+
+  });
+
+
+});

--- a/test/CollectionSpec.js
+++ b/test/CollectionSpec.js
@@ -49,6 +49,24 @@ describe("Collection", function() {
       }).to.throw();
     });
 
+    it("Throws Error if there is .attributes but no .cid", function() {
+      var c = new yobo.Collection();
+      expect(function() {
+        c.add({
+          attributes: {}
+        });
+      }).to.throw('Invalid Model instance, has .attributes but not .cid');
+    });
+
+    it("Throws Error if there is .cid but no .attributes", function() {
+      var c = new yobo.Collection();
+      expect(function() {
+        c.add({
+          cid: 'c123'
+        });
+      }).to.throw('Invalid Model instance, has .cid but not .attributes');
+    });
+
   });
 
 

--- a/test/CollectionSpec.js
+++ b/test/CollectionSpec.js
@@ -1,5 +1,6 @@
 
 var expect = require('chai').expect;
+var mocks = require('simple-mock');
 
 var yobo = require('../');
 
@@ -65,6 +66,26 @@ describe("Collection", function() {
           cid: 'c123'
         });
       }).to.throw('Invalid Model instance, has .cid but not .attributes');
+    });
+
+    it("Doesn't let objects through that Backbone immediately crashes on", function() {
+      var c = new yobo.Collection();
+      expect(function() {
+        c.add({
+          attributes: {},
+          cid: 'c1'
+        });
+      }).to.throw(/Backbone requires Model to have .on and .trigger functions/);
+    });
+
+    it("Does lets objects through without thorough compatibility checking", function() {
+      var c = new yobo.Collection();
+      c.add({
+        attributes: {},
+        cid: 'c1',
+        on: mocks.spy(),
+        trigger: mocks.spy()
+      });
     });
 
   });

--- a/test/ExportSpec.js
+++ b/test/ExportSpec.js
@@ -10,11 +10,11 @@ describe('yobo module', function() {
     expect(yobo.Backbone).to.exist();
   });
 
-  it('Exports .Collection, a shorthand for the (future) browser lib independent data structure', function() {
+  it('Exports .Collection, a shorthand for the data structure', function() {
     expect(yobo.Collection).to.exist();
   });
 
-  it('Exports .Model, the "class" that Collection does instanceof on', function() {
+  it('Exports .Model, the default collection item type', function() {
     expect(yobo.Model).to.exist();
   });
 


### PR DESCRIPTION
For discussion. Can we guard against the pitfall of a json attribute named 'attributes' being added and leading to weird errors?

Anyhow as discussed in #4 and #6 equally weird errors occur pretty often in modularized node.js and webpack code with the default instanceof check. Backbone won't err out there but your own code will because Backbone wrapped a perfectly useful model with another Model instance.
